### PR TITLE
Add support for org.eclipse.core.pki

### DIFF
--- a/org.eclipse.epp.mpc.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.epp.mpc.core/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.osgi;bundle-version="3.6.0",
  org.eclipse.core.net;bundle-version="1.2.100",
  org.eclipse.userstorage;bundle-version="[1.1.0,2.0.0)",
  org.eclipse.userstorage.oauth;bundle-version="[1.0.0,2.0.0)",
- org.eclipse.equinox.security;bundle-version="1.2.0"
+ org.eclipse.equinox.security;bundle-version="1.2.0",
+ org.apache.httpcomponents.client5.httpclient5
 Export-Package: org.eclipse.epp.internal.mpc.core;x-friends:="org.eclipse.epp.mpc.ui";
   uses:="org.osgi.framework,
    org.eclipse.epp.mpc.core.service,

--- a/org.eclipse.epp.mpc.core/src/org/eclipse/epp/internal/mpc/core/transport/httpclient/HttpClientFactory.java
+++ b/org.eclipse.epp.mpc.core/src/org/eclipse/epp/internal/mpc/core/transport/httpclient/HttpClientFactory.java
@@ -14,12 +14,16 @@ package org.eclipse.epp.internal.mpc.core.transport.httpclient;
 
 import java.util.List;
 
+import javax.net.ssl.SSLContext;
+
 import org.apache.hc.client5.http.auth.CredentialsStore;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.CookieStore;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
 import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.util.Timeout;
@@ -112,8 +116,18 @@ public class HttpClientFactory {
 
 	protected HttpClientBuilder builder() {
 		HttpClientBuilder builder = HttpClientBuilder.create();
+		
+		PoolingHttpClientConnectionManager connManager = null;
+		try {
+			SSLConnectionSocketFactory sslFactory = new SSLConnectionSocketFactory(SSLContext.getDefault());
+			connManager = PoolingHttpClientConnectionManagerBuilder.create().setSSLSocketFactory(sslFactory).build();
 
-		PoolingHttpClientConnectionManager connManager = new PoolingHttpClientConnectionManager();
+		} catch (Exception defaultProcess) {
+			// TODO Auto-generated catch block
+			//e.printStackTrace();
+			connManager = new PoolingHttpClientConnectionManager();
+		}
+
 		connManager.setDefaultMaxPerRoute(100);
 		connManager.setMaxTotal(200);
 		builder.setConnectionManager(connManager);


### PR DESCRIPTION
This change wlll turn on when org.eclipse.core.pki has been install and configured, otherwise packages is as it was.