### PR TITLE
Update to org.apache.hc.client5 5.3.x

### DIFF
--- a/org.eclipse.epp.mpc-parent/bundle/pom.xml
+++ b/org.eclipse.epp.mpc-parent/bundle/pom.xml
@@ -6,7 +6,7 @@
    <parent>
       <groupId>org.eclipse.epp.mpc</groupId>
       <artifactId>org.eclipse.epp.mpc-parent</artifactId>
-      <version>1.10.3-SNAPSHOT</version>
+      <version>1.11.0-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/org.eclipse.epp.mpc-parent/feature/pom.xml
+++ b/org.eclipse.epp.mpc-parent/feature/pom.xml
@@ -6,7 +6,7 @@
    <parent>
       <groupId>org.eclipse.epp.mpc</groupId>
       <artifactId>org.eclipse.epp.mpc-parent</artifactId>
-      <version>1.10.3-SNAPSHOT</version>
+      <version>1.11.0-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/org.eclipse.epp.mpc-parent/pom.xml
+++ b/org.eclipse.epp.mpc-parent/pom.xml
@@ -11,7 +11,7 @@
 
    <groupId>org.eclipse.epp.mpc</groupId>
    <artifactId>org.eclipse.epp.mpc-parent</artifactId>
-   <version>1.10.3-SNAPSHOT</version>
+   <version>1.11.0-SNAPSHOT</version>
    <packaging>pom</packaging>
 
    <properties>
@@ -22,7 +22,7 @@
       <enforced.java.version>[1.8.0,)</enforced.java.version>
       <java-jdk>SYSTEM</java-jdk>
 
-      <tycho-version>4.0.4</tycho-version>
+      <tycho-version>4.0.8</tycho-version>
       
       <qualifier-format>'v'yyyyMMdd-HHmm</qualifier-format>
 
@@ -198,10 +198,7 @@
                <artifactId>target-platform-configuration</artifactId>
                <version>${tycho-version}</version>
                <configuration>
-                  <resolver>p2</resolver>
                   <executionEnvironmentDefault>${java-bree}</executionEnvironmentDefault>
-                  <includePackedArtifacts>false</includePackedArtifacts>
-                  <ignoreTychoRepositories>true</ignoreTychoRepositories>
                   <target>
                      <artifact>
                         <groupId>org.eclipse.epp.mpc</groupId>
@@ -239,7 +236,6 @@
                   <timestampProvider>jgit</timestampProvider>
                   <!-- Changed back to "error" in the "release" profile. -->
                   <jgit.dirtyWorkingTree>warning</jgit.dirtyWorkingTree>
-                  <archiveSite>true</archiveSite>
                   <sourceReferences>
                      <generate>true</generate>
                   </sourceReferences>

--- a/org.eclipse.epp.mpc-target/pom.xml
+++ b/org.eclipse.epp.mpc-target/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.eclipse.epp.mpc</groupId>
       <artifactId>org.eclipse.epp.mpc-parent</artifactId>
-      <version>1.10.3-SNAPSHOT</version>
+      <version>1.11.0-SNAPSHOT</version>
       <relativePath>../org.eclipse.epp.mpc-parent</relativePath>
    </parent>
    <artifactId>org.eclipse.epp.mpc-target</artifactId>

--- a/org.eclipse.epp.mpc-target/staging.target
+++ b/org.eclipse.epp.mpc-target/staging.target
@@ -5,16 +5,17 @@
 <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.equinox.p2.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.31-I-builds"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.33-I-builds"/>
 <!-- <repository location="https://download.eclipse.org/eclipse/updates/4.30"/> -->
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 <unit id="org.hamcrest" version="0.0.0"/>
 <unit id="org.hamcrest.core" version="0.0.0"/>
 <unit id="org.hamcrest.library" version="0.0.0"/>
 <unit id="org.junit" version="0.0.0"/>
 <unit id="org.mockito.mockito-core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/latest"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
 <!-- repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2023-12"/ -->
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.epp.mpc.core.win32/META-INF/MANIFEST.MF
+++ b/org.eclipse.epp.mpc.core.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.epp.mpc.core.win32;singleton:=true
-Bundle-Version: 1.10.3.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
@@ -11,11 +11,11 @@ Require-Bundle: org.eclipse.osgi;bundle-version="3.6.0",
  com.sun.jna.platform;bundle-version="4.1.0"
 Import-Package: com.sun.jna;version="4.1.0",
  com.sun.jna.platform.win32;version="4.1.0",
- org.apache.hc.client5.http.auth;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.impl.auth;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.impl.classic;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.impl.win;version="[5.1.0,5.3.0)",
+ org.apache.hc.client5.http.auth;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.impl.auth;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.impl.classic;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.impl.win;version="[5.1.0,5.4.0)",
  org.apache.hc.core5.http.config;version="[5.1.0,5.3.0)",
- org.eclipse.epp.internal.mpc.core.transport.httpclient;bundle-version="1.10.3"
+ org.eclipse.epp.internal.mpc.core.transport.httpclient;bundle-version="1.11.0"
 Eclipse-PlatformFilter: (osgi.os=win32)
 Service-Component: OSGI-INF/services/*.xml

--- a/org.eclipse.epp.mpc.core.win32/pom.xml
+++ b/org.eclipse.epp.mpc.core.win32/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.epp.mpc</groupId>
     <artifactId>org.eclipse.epp.mpc-bundle</artifactId>
-    <version>1.10.3-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <relativePath>../org.eclipse.epp.mpc-parent/bundle</relativePath>
   </parent>
   <artifactId>org.eclipse.epp.mpc.core.win32</artifactId>

--- a/org.eclipse.epp.mpc.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.epp.mpc.core/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.epp.mpc.core;singleton:=true
-Bundle-Version: 1.10.3.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.osgi;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.6.0",
- org.apache.commons.logging;bundle-version="1.0.4",
+ org.apache.commons.commons-logging;bundle-version="1.0.4",
  org.eclipse.equinox.p2.repository;bundle-version="2.0.0",
  org.eclipse.core.net;bundle-version="1.2.100",
  org.eclipse.userstorage;bundle-version="[1.1.0,2.0.0)",
@@ -56,19 +56,19 @@ Export-Package: org.eclipse.epp.internal.mpc.core;x-friends:="org.eclipse.epp.mp
    org.eclipse.core.net.proxy",
  org.eclipse.epp.mpc.core.model,
  org.eclipse.epp.mpc.core.service;uses:="org.eclipse.epp.mpc.core.model,org.eclipse.core.runtime,org.eclipse.userstorage,org.apache.http.client.fluent"
-Import-Package: org.apache.hc.client5.http;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.auth;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.classic;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.classic.methods;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.config;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.cookie;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.entity;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.impl;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.impl.auth;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.impl.classic;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.impl.io;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.io;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.protocol;version="[5.1.0,5.3.0)",
+Import-Package: org.apache.hc.client5.http;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.auth;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.classic;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.classic.methods;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.config;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.cookie;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.entity;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.impl;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.impl.auth;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.impl.classic;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.impl.io;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.io;version="[5.1.0,5.4.0)",
+ org.apache.hc.client5.http.protocol;version="[5.1.0,5.4.0)",
  org.apache.hc.core5.http;version="[5.1.0,5.3.0)",
  org.apache.hc.core5.http.io;version="[5.1.0,5.3.0)",
  org.apache.hc.core5.http.io.entity;version="[5.1.0,5.3.0)",

--- a/org.eclipse.epp.mpc.core/OSGI-INF/services/org.eclipse.epp.mpc.core.servicehelper.xml
+++ b/org.eclipse.epp.mpc.core/OSGI-INF/services/org.eclipse.epp.mpc.core.servicehelper.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" name="org.eclipse.epp.mpc.core.servicehelper">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" deactivate="deactivate" name="org.eclipse.epp.mpc.core.servicehelper">
    <service>
       <provide interface="org.eclipse.epp.mpc.core.service.ServiceHelper"/>
       <provide interface="org.eclipse.epp.internal.mpc.core.ServiceHelperImpl"/>

--- a/org.eclipse.epp.mpc.core/OSGI-INF/services/org.eclipse.epp.mpc.core.transportfactory.legacy.xml
+++ b/org.eclipse.epp.mpc.core/OSGI-INF/services/org.eclipse.epp.mpc.core.transportfactory.legacy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" name="org.eclipse.epp.mpc.core.transportfactory.legacy">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" deactivate="deactivate" name="org.eclipse.epp.mpc.core.transportfactory.legacy">
    <property name="org.eclipse.epp.mpc.core.service.transport.legacy" type="Boolean" value="true"/>
    <property name="service.ranking" type="Integer" value="-2147483647"/>
    <service>

--- a/org.eclipse.epp.mpc.core/pom.xml
+++ b/org.eclipse.epp.mpc.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.epp.mpc</groupId>
     <artifactId>org.eclipse.epp.mpc-bundle</artifactId>
-    <version>1.10.3-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <relativePath>../org.eclipse.epp.mpc-parent/bundle</relativePath>
   </parent>
   <artifactId>org.eclipse.epp.mpc.core</artifactId>

--- a/org.eclipse.epp.mpc.dependencies.feature/feature.xml
+++ b/org.eclipse.epp.mpc.dependencies.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.epp.mpc.dependencies"
       label="%featureName"
-      version="1.10.3.qualifier"
+      version="1.11.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="2.0.2">

--- a/org.eclipse.epp.mpc.dependencies.feature/pom.xml
+++ b/org.eclipse.epp.mpc.dependencies.feature/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.epp.mpc</groupId>
     <artifactId>org.eclipse.epp.mpc-feature</artifactId>
-    <version>1.10.3-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <relativePath>../org.eclipse.epp.mpc-parent/feature</relativePath>
   </parent>
   <artifactId>org.eclipse.epp.mpc.dependencies</artifactId>

--- a/org.eclipse.epp.mpc.feature/feature.xml
+++ b/org.eclipse.epp.mpc.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.epp.mpc"
       label="%featureName"
-      version="1.10.3.qualifier"
+      version="1.11.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.epp.mpc.ui"
       license-feature="org.eclipse.license"

--- a/org.eclipse.epp.mpc.feature/pom.xml
+++ b/org.eclipse.epp.mpc.feature/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.epp.mpc</groupId>
     <artifactId>org.eclipse.epp.mpc-feature</artifactId>
-    <version>1.10.3-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <relativePath>../org.eclipse.epp.mpc-parent/feature</relativePath>
   </parent>
   <artifactId>org.eclipse.epp.mpc</artifactId>

--- a/org.eclipse.epp.mpc.help.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.epp.mpc.help.ui/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.epp.mpc.help.ui;singleton:=true
-Bundle-Version: 1.10.3.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.help;bundle-version="3.5.0"

--- a/org.eclipse.epp.mpc.help.ui/pom.xml
+++ b/org.eclipse.epp.mpc.help.ui/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.eclipse.epp.mpc</groupId>
     <artifactId>org.eclipse.epp.mpc-bundle</artifactId>
-    <version>1.10.3-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <relativePath>../org.eclipse.epp.mpc-parent/bundle</relativePath>
   </parent>
   <artifactId>org.eclipse.epp.mpc.help.ui</artifactId>

--- a/org.eclipse.epp.mpc.site/pom.xml
+++ b/org.eclipse.epp.mpc.site/pom.xml
@@ -16,7 +16,7 @@
    <parent>
       <groupId>org.eclipse.epp.mpc</groupId>
       <artifactId>org.eclipse.epp.mpc-parent</artifactId>
-      <version>1.10.3-SNAPSHOT</version>
+      <version>1.11.0-SNAPSHOT</version>
       <relativePath>../org.eclipse.epp.mpc-parent</relativePath>
    </parent>
    <artifactId>org.eclipse.epp.mpc.site</artifactId>

--- a/org.eclipse.epp.mpc.tests.catalog/META-INF/MANIFEST.MF
+++ b/org.eclipse.epp.mpc.tests.catalog/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Marketplace Client Test Catalog
 Bundle-SymbolicName: org.eclipse.epp.mpc.tests.catalog;singleton:=true
-Bundle-Version: 1.10.3.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Vendor: Eclipse Marketplace Client
-Require-Bundle: org.eclipse.epp.mpc.ui;bundle-version="1.10.3"
+Require-Bundle: org.eclipse.epp.mpc.ui;bundle-version="1.11.0"

--- a/org.eclipse.epp.mpc.tests.catalog/pom.xml
+++ b/org.eclipse.epp.mpc.tests.catalog/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.eclipse.epp.mpc</groupId>
     <artifactId>org.eclipse.epp.mpc-bundle</artifactId>
-    <version>1.10.3-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <relativePath>../org.eclipse.epp.mpc-parent/bundle</relativePath>
   </parent>
   <artifactId>org.eclipse.epp.mpc.tests.catalog</artifactId>

--- a/org.eclipse.epp.mpc.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.epp.mpc.tests/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Marketplace Client Tests
 Bundle-SymbolicName: org.eclipse.epp.mpc.tests
-Bundle-Version: 1.10.3.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Vendor: Eclipse Marketplace Client
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.osgi;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.6.0",
- org.eclipse.epp.mpc.core;bundle-version="[1.10.3,2.0.0)",
- org.eclipse.epp.mpc.ui;bundle-version="[1.10.3,2.0.0)",
+ org.eclipse.epp.mpc.core;bundle-version="[1.11.0,2.0.0)",
+ org.eclipse.epp.mpc.ui;bundle-version="[1.11.0,2.0.0)",
  org.junit;bundle-version="4.7.0",
  org.eclipse.equinox.p2.repository;bundle-version="2.0.0",
  org.eclipse.equinox.p2.core;bundle-version="2.0.0",
@@ -27,10 +27,10 @@ Require-Bundle: org.eclipse.osgi;bundle-version="3.6.0",
  org.apache.httpcomponents.httpclient,
  org.slf4j.api;bundle-version="1.7.30",
  org.mockito.mockito-core;bundle-version="4.8.1"
-Import-Package: org.apache.hc.client5.http.auth;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.classic;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.classic.methods;version="[5.1.0,5.3.0)",
- org.apache.hc.client5.http.impl.classic;version="[5.1.0,5.3.0)",
+Import-Package: org.apache.hc.client5.http.auth;version="[5.1.0,6.0.0)",
+ org.apache.hc.client5.http.classic;version="[5.1.0,6.0.0)",
+ org.apache.hc.client5.http.classic.methods;version="[5.1.0,6.0.0)",
+ org.apache.hc.client5.http.impl.classic;version="[5.1.0,6.0.0)",
  org.apache.hc.core5.http;version="[5.1.0,5.3.0)",
  org.apache.hc.core5.http.config;version="[5.1.0,5.3.0)",
  org.apache.hc.core5.http.io.support;version="5.1.2",

--- a/org.eclipse.epp.mpc.tests/pom.xml
+++ b/org.eclipse.epp.mpc.tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.epp.mpc</groupId>
     <artifactId>org.eclipse.epp.mpc-bundle</artifactId>
-    <version>1.10.3-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <relativePath>../org.eclipse.epp.mpc-parent/bundle</relativePath>
   </parent>
   <artifactId>org.eclipse.epp.mpc.tests</artifactId>

--- a/org.eclipse.epp.mpc.ui.css/META-INF/MANIFEST.MF
+++ b/org.eclipse.epp.mpc.ui.css/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.epp.mpc.ui.css;singleton:=true
-Bundle-Version: 1.10.3.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.e4.ui.services;bundle-version="[1.3.0,2.0.0)",

--- a/org.eclipse.epp.mpc.ui.css/pom.xml
+++ b/org.eclipse.epp.mpc.ui.css/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.eclipse.epp.mpc</groupId>
     <artifactId>org.eclipse.epp.mpc-bundle</artifactId>
-    <version>1.10.3-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <relativePath>../org.eclipse.epp.mpc-parent/bundle</relativePath>
   </parent>
   <artifactId>org.eclipse.epp.mpc.ui.css</artifactId>

--- a/org.eclipse.epp.mpc.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.epp.mpc.ui/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.epp.mpc.ui;singleton:=true
-Bundle-Version: 1.10.3.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
- org.eclipse.epp.mpc.core;bundle-version="[1.10.3,2.0.0)",
- org.eclipse.epp.mpc.ui.css;bundle-version="[1.10.3,2.0.0)",
+ org.eclipse.epp.mpc.core;bundle-version="[1.11.0,2.0.0)",
+ org.eclipse.epp.mpc.ui.css;bundle-version="[1.11.0,2.0.0)",
  org.eclipse.ui;bundle-version="3.6.0",
  org.eclipse.equinox.p2.ui.discovery;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.equinox.p2.discovery;bundle-version="[1.0.0,2.0.0)",

--- a/org.eclipse.epp.mpc.ui/OSGI-INF/services/org.eclipse.epp.mpc.ui.resources.xml
+++ b/org.eclipse.epp.mpc.ui/OSGI-INF/services/org.eclipse.epp.mpc.ui.resources.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" name="org.eclipse.epp.mpc.ui.resources">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" deactivate="deactivate" name="org.eclipse.epp.mpc.ui.resources">
    <service>
       <provide interface="org.eclipse.epp.internal.mpc.ui.MarketplaceClientUiResources"/>
    </service>

--- a/org.eclipse.epp.mpc.ui/pom.xml
+++ b/org.eclipse.epp.mpc.ui/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.eclipse.epp.mpc</groupId>
     <artifactId>org.eclipse.epp.mpc-bundle</artifactId>
-    <version>1.10.3-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <relativePath>../org.eclipse.epp.mpc-parent/bundle</relativePath>
   </parent>
   <artifactId>org.eclipse.epp.mpc.ui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>org.eclipse.epp.mpc-parent</artifactId>
     <groupId>org.eclipse.epp.mpc</groupId>
-    <version>1.10.3-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <relativePath>org.eclipse.epp.mpc-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
- Update to a 1.11.0 version.
- Update to Tycho 4.0.8.
- Remove maven properties that produce warnings.
- Update staging target for 4.33 and orbit milestone/latest.
- Update to allow up to org.apache.hc.client5 version 5.4.0.
- Update service xml to latest generated version with activate="active".

https://github.com/eclipse-mpc/epp.mpc/issues/10