### PR TITLE
Revert "Bump xalan:xalan from 2.7.2 to 2.7.3 in /org.eclipse.epp.mpc.site"

### DIFF
--- a/org.eclipse.epp.mpc.site/pom.xml
+++ b/org.eclipse.epp.mpc.site/pom.xml
@@ -117,7 +117,7 @@
                <dependency>
                   <groupId>xalan</groupId>
                   <artifactId>xalan</artifactId>
-                  <version>2.7.3</version>
+                  <version>2.7.2</version>
                </dependency>
                <dependency>
                   <groupId>org.apache.ant</groupId>


### PR DESCRIPTION
Reverts eclipse-mpc/epp.mpc#29 . It breaks the build as can be seen at https://ci.eclipse.org/mpc/job/epp-mpc-ci/5734/console . In order to get better connection with GH UI there is https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6438 which should hopefully allow to see such things earlier as now one has to find things manually by crawling the JIPP.