### PR TITLE
Stop building source features

### DIFF
--- a/org.eclipse.epp.mpc-parent/feature/pom.xml
+++ b/org.eclipse.epp.mpc-parent/feature/pom.xml
@@ -13,63 +13,6 @@
    <artifactId>org.eclipse.epp.mpc-feature</artifactId>
    <packaging>pom</packaging>
 
-   <build>
-      <plugins>
-         <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-source-plugin</artifactId>
-            <configuration>
-               <excludes>
-                  <plugin id="org.eclipse.epp.mpc.help.ui" />
-                  <plugin id="org.apache.httpcomponents.httpclient"/>
-                  <plugin id="org.apache.httpcomponents.httpcore"/>
-               </excludes>
-            </configuration>
-         </plugin>
-         <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-plugin</artifactId>
-         </plugin>
-      </plugins>
-
-      <pluginManagement>
-         <plugins>
-            <plugin>
-               <groupId>org.eclipse.tycho</groupId>
-               <artifactId>tycho-source-plugin</artifactId>
-               <version>${tycho-version}</version>
-               <configuration>
-                  <!-- Non-breakable space, as normal spaces are trimmed. -->
-                  <labelSuffix>&#xA0;(Sources)</labelSuffix>
-               </configuration>
-               <executions>
-                  <execution>
-                     <id>feature-source</id>
-                     <phase>package</phase>
-                     <goals>
-                        <goal>feature-source</goal>
-                     </goals>
-                  </execution>
-               </executions>
-            </plugin>
-            <plugin>
-               <groupId>org.eclipse.tycho</groupId>
-               <artifactId>tycho-p2-plugin</artifactId>
-               <executions>
-                  <execution>
-                     <!-- Attach metadata only after the "generate-source-feature" execution. -->
-                     <id>attach-p2-metadata</id>
-                     <phase>package</phase>
-                     <goals>
-                        <goal>p2-metadata</goal>
-                     </goals>
-                  </execution>
-               </executions>
-            </plugin>
-         </plugins>
-      </pluginManagement>
-   </build>
-
    <profiles>
       <profile>
          <id>release</id>

--- a/org.eclipse.epp.mpc.site/category.xml
+++ b/org.eclipse.epp.mpc.site/category.xml
@@ -6,13 +6,7 @@
    <feature id="org.eclipse.epp.mpc" version="0.0.0">
       <category name="EPP Marketplace Client"/>
    </feature>
-   <feature id="org.eclipse.epp.mpc.source" version="0.0.0">
-      <category name="no.category"/>
-   </feature>
    <feature id="org.eclipse.epp.mpc.dependencies" version="0.0.0">
-      <category name="no.category"/>
-   </feature>
-   <feature id="org.eclipse.epp.mpc.dependencies.source" version="0.0.0">
       <category name="no.category"/>
    </feature>
    <category-def name="EPP Marketplace Client" label="EPP Marketplace Client">

--- a/org.eclipse.epp.mpc.site/pom.xml
+++ b/org.eclipse.epp.mpc.site/pom.xml
@@ -90,6 +90,7 @@
             <artifactId>tycho-p2-repository-plugin</artifactId>
             <configuration>
                <includeAllDependencies>false</includeAllDependencies>
+               <includeAllSources>true</includeAllSources>
                <compress>false</compress>
                <xzCompress>false</xzCompress>
             </configuration>


### PR DESCRIPTION
They are to be deprecated in Tycho 5 and removed in 6 as both Tycho and PDE support source bundles without them.