### PR TITLE
Fix broken build/test setup and restore/extend GHA workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,66 +1,273 @@
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
 name: Build
 
-on:
+on:  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
   push:
-    branches: [master]
+    branches-ignore:  # build all branches except:
+    - 'dependabot/**'  # prevent GHA triggered twice (once for commit to the branch and once for opening/syncing the PR)
+    tags-ignore:  # don't build tags
+    - '**'
+    paths-ignore:
+    - '**/*.md'
+    - '.github/*.yml'
+    - '.github/workflows/codeql.yml'
+    - '.github/workflows/licensecheck.yml'
+    - '**/.project'
+    - '**/.settings/*.prefs'
+    - '.gitignore'
+    - '.actrc'
+    - 'Jenkinsfile'
   pull_request:
+    paths-ignore:
+    - '**/*.md'
+    - '.github/*.yml'
+    - '.github/workflows/codeql.yml'
+    - '.github/workflows/licensecheck.yml'
+    - '**/.project'
+    - '**/.settings/*.prefs'
+    - '.gitignore'
+    - '.actrc'
+    - 'Jenkinsfile'
+  workflow_dispatch:
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
+    inputs:
+      additional_maven_args:
+        description: 'Additional Maven Args'
+        required: false
+        default: ''
+      debug-with-ssh:
+        description: "Start an SSH session for debugging purposes at the end of the build:"
+        default: never
+        type: choice
+        options: [ always, on_failure, on_failure_or_cancelled, never ]
+      debug-with-ssh-only-for-actor:
+        description: "Limit access to the SSH session to the GitHub user that triggered the job."
+        default: true
+        type: boolean
+
+
+defaults:
+  run:
+    shell: bash
+
+
+env:
+  JAVA_VERSION: 21
+
 
 jobs:
-  build:
 
-    runs-on: ubuntu-latest
+  ###########################################################
+  build:
+  ###########################################################
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:  # https://github.com/actions/runner-images#available-images
+        - ubuntu-latest
+        - macos-15-intel  # Intel
+        - macos-latest  # ARM
+        - windows-latest
+        target-platform:
+        - oldest
+        - latest
+        - staging
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v1
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Set up JDK 21
-      uses: actions/setup-java@v3
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-    
-    - name: Setup Maven
-      # todo change?
-      uses: stCarolas/setup-maven@v4.2
-      with:
-        maven-version: 3.9.5
+    - name: "Show: GitHub context"
+      env:
+        GITHUB_CONTEXT: ${{ toJSON(github) }}
+      run: printf '%s' "$GITHUB_CONTEXT" | python -m json.tool
 
-    - name: Build
-      uses: GabrielBB/xvfb-action@v1
+
+    - name: "Show: environment variables"
+      run: env | sort
+
+
+    - name: Git Checkout
+      uses: actions/checkout@v5  # https://github.com/actions/checkout
       with:
-        run: >
-          mvn verify
-          -Dmaven.test.failure.ignore=true
-          -Dtycho.disableP2Mirrors=true
-          -Dorg.eclipse.swt.browser.UseWebKitGTK=true
-          -Dorg.eclipse.swt.browser.DefaultType=WebKit
-          -Dtycho.localArtifacts=ignore
-          -Dsurefire.timeout=1500
-          -Dhttp.nonProxyHosts=localhost
-          
-    - name: 'Upload Screenshots'
-      uses: actions/upload-artifact@v2
+        fetch-depth: 0  # required to prevent tycho-p2-extras-plugin:compare-version-with-baseline potentially failing the build
+
+
+    - name: Configure fast APT repository mirror
+      if: runner.os == 'Linux'
+      uses: vegardit/fast-apt-mirror.sh@v1
+
+
+    - name: "Install: Linux packages 📦"
+      if: runner.os == 'Linux'
+      run: |
+        set -eux
+        sudo apt-get install --no-install-recommends -y xvfb
+
+        # prevents: "Failed to execute child process “dbus-launch” (No such file or directory)"
+        sudo apt-get install --no-install-recommends -y dbus-x11
+
+        # prevents: "dbind-WARNING **: 20:17:55.046: AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files"
+        # see https://gist.github.com/jeffcogswell/62395900725acef1c0a5a608f7eb7a05
+        sudo apt-get install --no-install-recommends -y at-spi2-core
+
+        # prevents:
+        #  java.lang.UnsatisfiedLinkError: Could not load SWT library. Reasons:
+        #    no swt-pi4-gtk-4956r13 in java.library.path: /usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
+        #    no swt-pi4-gtk in java.library.path: /usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
+        #    no swt-pi4 in java.library.path: /usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
+        sudo apt-get install --no-install-recommends -y libswt-gtk-*-java
+
+        # required by org.eclipse.epp.mpc.tests.ui.wizard.MarketplaceWizardTest.testNews
+        # see https://www.eclipse.org/swt/faq.php#browserwebkitgtk
+        sudo apt-get install -y libwebkit2gtk-4.1-0
+
+        # prevents: Gtk-WARNING **: 22:59:43.054: Could not load a pixbuf from /org/gtk/libgtk/theme/Adwaita/assets/check-symbolic.svg.
+        sudo apt-get install --no-install-recommends -y adwaita-icon-theme librsvg2-common gdk-pixbuf2.0-bin
+        sudo /usr/lib/*-linux-gnu/gdk-pixbuf-*/gdk-pixbuf-query-loaders --update-cache
+        echo "GDK_BACKEND=x11" >> $GITHUB_ENV
+
+
+    - name: "Cache: Local Maven Repository"
+      uses: actions/cache@v4
       with:
-        name: org.eclipse.epp.mpc.tests-target-screenshots
+        # Excluded sub directory not working https://github.com/actions/toolkit/issues/713
+        path: |
+          ~/.m2/repository/*
+          !~/.m2/repository/.cache/tycho
+          !~/.m2/repository/.meta/p2-artifacts.properties
+          !~/.m2/repository/p2
+          !~/.m2/repository/*SNAPSHOT*
+        key: ${{ runner.os }}-${{ runner.arch }}-repo-mvn-${{ hashFiles('**/pom.xml') }}
+
+
+    - name: "Cache: Local Tycho Repository"
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.m2/repository/.cache/tycho
+          ~/.m2/repository/.meta/p2-artifacts.properties
+          ~/.m2/repository/p2
+        key: ${{ runner.os }}-${{ runner.arch }}-repo-tycho-${{ hashFiles(format('org.eclipse.epp.mpc-target/{0}.target', matrix.target-platform)) }}
+
+
+    - name: "Install: JDK ${{ env.JAVA_VERSION }} ☕"
+      uses: actions/setup-java@v5  # https://github.com/actions/setup-java
+      with:
+        distribution: temurin
+        java-version: ${{ env.JAVA_VERSION }}
+
+
+    - name: Setup Maven
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: 3.9.11
+
+
+    - name: "Build with Maven 🔨"
+      continue-on-error: ${{ matrix.target-platform == 'staging' }}
+      run: |
+        set -euo pipefail
+
+        MAVEN_OPTS="${MAVEN_OPTS:-}"
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
+          MAVEN_OPTS+=" -Djava.security.egd=file:/dev/urandom" # https://www.baeldung.com/java-security-egd#bd-testing-the-effect-of-javasecurityegd
+        else
+          MAVEN_OPTS+=" -Djava.security.egd=file:/dev/./urandom" # https://stackoverflow.com/questions/58991966/what-java-security-egd-option-is-for/59097932#59097932
+        fi
+        MAVEN_OPTS+=" -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS" # https://stackoverflow.com/questions/5120470/how-to-time-the-different-stages-of-maven-execution/49494561#49494561
+        MAVEN_OPTS+=" -Xmx1024m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Dhttps.protocols=TLSv1.3,TLSv1.2"
+        export MAVEN_OPTS
+        echo "MAVEN_OPTS: $MAVEN_OPTS"
+
+        if [[ ${ACT:-} == "true" ]]; then # when running locally using nektos/act
+          maven_args="-Djgit.dirtyWorkingTree=warning"
+        else
+          maven_args="--no-transfer-progress"
+        fi
+
+        # prevent "org.eclipse.swt.SWTError: No more handles [gtk_init_check() failed]" on Linux
+        ${{ runner.os == 'Linux' && 'xvfb-run --auto-servernum --server-args="-screen 0 1600x900x24" \' || '' }}
+        mvn \
+          --errors \
+          --update-snapshots \
+          --batch-mode \
+          --show-version \
+          -Declipse.p2.mirrors=false \
+          -Dtarget-platform=${{ matrix.target-platform }} \
+          -Dorg.eclipse.swt.browser.UseWebKitGTK=true \
+          -Dorg.eclipse.swt.browser.DefaultType=WebKit \
+          -Dtycho.localArtifacts=ignore \
+          -Dsurefire.rerunFailingTestsCount=3 \
+          -Dsurefire.timeout=1500 \
+          $maven_args \
+          ${{ github.event.inputs.additional_maven_args }} \
+          clean verify || (
+            rc=$?
+            if [[ ${ACT:-} != "true" ]]; then
+              find . -path "*/target/work/data/.metadata/.log" | while IFS= read -r file; do
+                echo "::group::$file"
+                  cat "$file"
+                echo "::endgroup::"
+              done
+            fi
+            exit $rc
+          )
+
+
+    - name: "Upload: Screenshots"
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: org.eclipse.epp.mpc.tests-target-screenshots-${{matrix.target-platform}}-${{matrix.os}}
         path: org.eclipse.epp.mpc.tests/target/screenshots/**
         retention-days: 3
-  
-    - name: 'Upload Screenshots'
-      uses: actions/upload-artifact@v2
+
+
+    - name: "Upload: .metadata/.log"
+      uses: actions/upload-artifact@v4
+      if: always()
       with:
-        name: org.eclipse.epp.mpc.tests-log
+        name: org.eclipse.epp.mpc.tests-log-${{matrix.target-platform}}-${{matrix.os}}
         path: org.eclipse.epp.mpc.tests/target/work/data/.metadata/.log
+        include-hidden-files: true
         retention-days: 3
-        
-        
-    - name: 'Upload Screenshots Backup'
-      uses: actions/upload-artifact@v2
+
+
+    - name: "Upload: .metadata/**"
+      uses: actions/upload-artifact@v4
+      if: always()
       with:
-        name: org.eclipse.epp.mpc.tests-log-all
+        name: org.eclipse.epp.mpc.tests-log-all-${{matrix.target-platform}}-${{matrix.os}}
         path: org.eclipse.epp.mpc.tests/target/work/data/.metadata/**
+        include-hidden-files: true
         retention-days: 3
+
+
+    ##################################################
+    # Setup SSH debug session
+    ##################################################
+    - name: "SSH session for debugging: check"
+      id: DEBUG_SSH_SESSSION_CHECK
+      if: always()
+      run: |
+        set -eu
+
+        when="${{ inputs.debug-with-ssh }}"
+
+        if [[ $when == "always" ]] || case "${{ job.status }}" in
+          success)   [[ $when == "always" ]] ;;
+          cancelled) [[ $when == "on_failure_or_cancelled" ]] ;;
+          failure)   [[ $when == "on_failure"* ]] ;;
+        esac; then
+          echo "start_ssh_session=true" | tee -a "$GITHUB_OUTPUT"
+        fi
+
+
+    - name: "SSH session for debugging: start"
+      uses: mxschmitt/action-tmate@v3  # https://github.com/mxschmitt/action-tmate
+      if: always() && steps.DEBUG_SSH_SESSSION_CHECK.outputs.start_ssh_session
+      with:
+        limit-access-to-actor: ${{ inputs.debug-with-ssh-only-for-actor }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,28 +2,56 @@ pipeline {
 	agent {
 		label 'ubuntu-latest'
 	}
+
 	triggers {
 		githubPush()
 	}
+
 	options {
-		buildDiscarder(logRotator(numToKeepStr:'5'))
-		disableConcurrentBuilds(abortPrevious: true)
+		timeout(time: 20, unit: 'MINUTES')
+		buildDiscarder(logRotator(numToKeepStr:'10'))
+		disableConcurrentBuilds(abortPrevious: false)
 	}
+
 	tools {
-		maven 'apache-maven-latest'
 		jdk   'temurin-jdk21-latest'
+		maven 'apache-maven-latest'
 	}
+
 	stages {
 		stage('Build') {
 			steps {
 				wrap([$class: 'Xvnc', useXauthority: true]) {
-					sh "mvn clean verify -fae"
+					sh '''
+						set -euo pipefail
+
+						MAVEN_OPTS="${MAVEN_OPTS:-}"
+						MAVEN_OPTS+=" -Djava.security.egd=file:/dev/./urandom" # https://stackoverflow.com/questions/58991966/what-java-security-egd-option-is-for/59097932#59097932
+						MAVEN_OPTS+=" -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS" # https://stackoverflow.com/questions/5120470/how-to-time-the-different-stages-of-maven-execution/49494561#49494561
+						MAVEN_OPTS+=" -Xmx1024m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Dhttps.protocols=TLSv1.3,TLSv1.2"
+						export MAVEN_OPTS
+						echo "MAVEN_OPTS: $MAVEN_OPTS"
+
+						mvn clean verify \
+							--errors \
+							--update-snapshots \
+							--batch-mode \
+							--show-version \
+							--fail-at-end \
+							--no-transfer-progress \
+							-Declipse.p2.mirrors=false \
+							-Djgit.dirtyWorkingTree=warning \
+							-Dtycho.localArtifacts=ignore \
+							-Dsurefire.rerunFailingTestsCount=3 \
+							-Dsurefire.timeout=1500 \
+							-Dtarget-platform=latest.target
+						'''
 				}
 			}
-			post {	
+			post {
 				always {
-					junit '**/target/surefire-reports/*.xml'
 					archiveArtifacts artifacts: '**/target/repository/**,**/target/screenshots/**'
+					junit '**/target/surefire-reports/TEST-*.xml'
 					recordIssues publishAllIssues: true, tools: [mavenConsole(), java(), eclipse(), javaDoc()]
 				}
 			}

--- a/org.eclipse.epp.mpc-parent/pom.xml
+++ b/org.eclipse.epp.mpc-parent/pom.xml
@@ -22,7 +22,7 @@
       <java-jdk>SYSTEM</java-jdk>
 
       <tycho-version>4.0.13</tycho-version>
-      
+
       <qualifier-format>'v'yyyyMMdd-HHmm</qualifier-format>
 
       <skip-source-check>true</skip-source-check>
@@ -187,6 +187,11 @@
                         <os>macosx</os>
                         <ws>cocoa</ws>
                         <arch>x86_64</arch>
+                     </environment>
+                     <environment>
+                        <os>macosx</os>
+                        <ws>cocoa</ws>
+                        <arch>aarch64</arch>
                      </environment>
                   </environments>
                </configuration>

--- a/org.eclipse.epp.mpc-target/latest.target
+++ b/org.eclipse.epp.mpc-target/latest.target
@@ -1,34 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="MPC Target Platform - latest release" sequenceNumber="21">
+<?pde version="3.8"?>
+<target name="MPC Target Platform targeting current stable Eclipse release" sequenceNumber="21">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.equinox.p2.sdk.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/eclipse/updates/4.17"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.hamcrest" version="0.0.0"/>
-<unit id="org.hamcrest.core" version="0.0.0"/>
-<unit id="org.hamcrest.library" version="0.0.0"/>
-<unit id="org.junit" version="0.0.0"/>
-<unit id="org.mockito" version="0.0.0"/>
-<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20190827152740/repository"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.epp.mpc.apache.httpclient.feature.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.epp.mpc.apache.httpclient.feature.source.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/mpc/httpclient/drops/I-builds/201905030009"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/cbi/updates/license/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.swtbot.generator.feature.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/technology/swtbot/releases/latest"/>
-</location>
-</locations>
+
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/cbi/updates/license"/>
+      <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
+    </location>
+
+    <!-- 4.35 = Eclipse 2025-09 -->
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/eclipse/updates/4.37"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.equinox.p2.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+    </location>
+
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/latest"/>
+      <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
+      <unit id="org.hamcrest" version="0.0.0"/>
+      <unit id="org.hamcrest.core" version="0.0.0"/>
+      <unit id="org.hamcrest.library" version="0.0.0"/>
+      <unit id="org.junit" version="0.0.0"/>
+      <unit id="org.mockito.mockito-core" version="0.0.0"/>
+    </location>
+
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/technology/swtbot/releases/latest"/>
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.swtbot.generator.feature.feature.group" version="0.0.0"/>
+      <unit id="org.slf4j.api" version="0.0.0"/>
+    </location>
+
+  </locations>
+
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 </target>

--- a/org.eclipse.epp.mpc-target/oldest.target
+++ b/org.eclipse.epp.mpc-target/oldest.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="MPC Target Platform targeting integration builds of the next Eclipse release" sequenceNumber="21">
+<target name="MPC Target Platform targeting oldest supported Eclipse release" sequenceNumber="21">
 <locations>
 
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -8,9 +8,9 @@
       <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
     </location>
 
-    <!-- 4.38 = Eclipse 2025-12 -->
+    <!-- 4.32 = Eclipse 2024-06 first Eclipse release that was shipped with JRE 21 by default -->
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.eclipse.org/eclipse/updates/4.38-I-builds"/>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.32"/>
       <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.equinox.p2.sdk.feature.group" version="0.0.0"/>
@@ -18,7 +18,7 @@
     </location>
 
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/latest"/>
       <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
       <unit id="org.hamcrest" version="0.0.0"/>
       <unit id="org.hamcrest.core" version="0.0.0"/>

--- a/org.eclipse.epp.mpc.core/src/org/eclipse/epp/internal/mpc/core/transport/httpclient/HttpClientTransport.java
+++ b/org.eclipse.epp.mpc.core/src/org/eclipse/epp/internal/mpc/core/transport/httpclient/HttpClientTransport.java
@@ -123,9 +123,10 @@ public class HttpClientTransport implements ITransport {
 			}
 
 			@Override
-			protected InputStream handleResponse(ClassicHttpResponse response)
-					throws ClientProtocolException, IOException {
-				HttpEntity entity = response.getEntity();
+			protected InputStream handleResponseEntity(HttpEntity entity) throws IOException {
+				if (entity == null) {
+					return handleEmptyResponse();
+				}
 				byte[] contentBytes = EntityUtils.toByteArray(entity);
 				return new ByteArrayInputStream(contentBytes);
 			}

--- a/org.eclipse.epp.mpc.tests/All MPC Tests.launch
+++ b/org.eclipse.epp.mpc.tests/All MPC Tests.launch
@@ -13,6 +13,7 @@
 <booleanAttribute key="default" value="false"/>
 <booleanAttribute key="includeOptional" value="true"/>
 <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
 <listEntry value="/org.eclipse.epp.mpc.tests"/>
 </listAttribute>
@@ -23,8 +24,10 @@
 <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.epp.mpc.tests"/>

--- a/org.eclipse.epp.mpc.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.epp.mpc.tests/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.eclipse.epp.mpc.tests
 Bundle-Version: 1.13.0.qualifier
 Bundle-Vendor: Eclipse Marketplace Client
 Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.osgi;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.epp.mpc.core;bundle-version="[1.13.0,2.0.0)",

--- a/org.eclipse.epp.mpc.tests/pom.xml
+++ b/org.eclipse.epp.mpc.tests/pom.xml
@@ -16,6 +16,7 @@
     <test-args>-ea</test-args>
     <test-proxy></test-proxy>
     <test-app-args></test-app-args>
+    <tycho-surefire-plugin.vmargs></tycho-surefire-plugin.vmargs>
   </properties>
 
   <profiles>
@@ -46,6 +47,18 @@
          </pluginManagement>
        </build>
     </profile>
+    <!-- Automatic profile for Mac-specific settings -->
+    <profile>
+      <id>macos</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <properties>
+        <tycho-surefire-plugin.vmargs>-XstartOnFirstThread</tycho-surefire-plugin.vmargs>
+      </properties>
+    </profile>
   </profiles>
 
   <build>
@@ -61,9 +74,9 @@
               <product>org.eclipse.sdk.ide</product>
               <application>org.eclipse.ui.ide.workbench</application>
               <testClass>${test-suite}</testClass>
-              <argLine>-Xmx256m -Djava.io.tmpdir=${project.build.directory}/temp ${test-args} ${test-proxy}</argLine>
+              <argLine>-Xmx256m ${tycho-surefire-plugin.vmargs} -Djava.io.tmpdir=${project.build.directory}/temp ${test-args} ${test-proxy}</argLine>
               <appArgLine>${test-app-args}</appArgLine>
-              
+
               <!-- run all tests with a space in the application path (this is the osgi.install.area, but the configuration area should follow suit -->
               <work>${project.build.directory}/work/test rcp</work>
             </configuration>

--- a/org.eclipse.epp.mpc.tests/src/org/eclipse/epp/mpc/tests/service/CatalogServiceTest.java
+++ b/org.eclipse.epp.mpc.tests/src/org/eclipse/epp/mpc/tests/service/CatalogServiceTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.epp.internal.mpc.core.ServiceLocator;
 import org.eclipse.epp.internal.mpc.core.model.Catalog;
 import org.eclipse.epp.internal.mpc.core.service.CatalogService;
 import org.eclipse.epp.internal.mpc.core.util.ServiceUtil;
@@ -89,8 +88,8 @@ public class CatalogServiceTest {
 		ServiceRegistration<ICatalogService> registration = bundleContext.registerService(ICatalogService.class,
 				new MockCatalogService(), ServiceUtil.serviceRanking(Integer.MAX_VALUE, null));
 		try {
-			catalogService = ServiceLocator.getInstance().getCatalogService();
-			List<? extends ICatalog> catalogs = catalogService.listCatalogs(null);
+			catalogService = serviceLocator.getCatalogService();
+			List<? extends ICatalog> catalogs = catalogService.listCatalogs(new NullProgressMonitor());
 			assertEquals(1, catalogs.size());
 			assertEquals("mock", catalogs.get(0).getId());
 		} finally {

--- a/org.eclipse.epp.mpc.tests/src/org/eclipse/epp/mpc/tests/service/ServiceLocatorTest.java
+++ b/org.eclipse.epp.mpc.tests/src/org/eclipse/epp/mpc/tests/service/ServiceLocatorTest.java
@@ -17,8 +17,10 @@ import static org.junit.Assert.*;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore("Not yet implemented")
 public class ServiceLocatorTest {
 
 	@Before
@@ -31,16 +33,19 @@ public class ServiceLocatorTest {
 
 	@Test
 	public void testGetMarketplaceServiceString() {
+		// TODO implement
 		fail("Not yet implemented");
 	}
 
 	@Test
 	public void testGetCatalogService() {
+		// TODO implement
 		fail("Not yet implemented");
 	}
 
 	@Test
 	public void testGetInstance() {
+		// TODO implement
 		fail("Not yet implemented");
 	}
 

--- a/org.eclipse.epp.mpc.tests/src/org/eclipse/epp/mpc/tests/service/xml/UnmarshallerTest.java
+++ b/org.eclipse.epp.mpc.tests/src/org/eclipse/epp/mpc/tests/service/xml/UnmarshallerTest.java
@@ -15,6 +15,7 @@ package org.eclipse.epp.mpc.tests.service.xml;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.anyOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -513,7 +514,9 @@ public class UnmarshallerTest {
 			fail("Expected UnmarshalException");
 		} catch (UnmarshalException e) {
 			IStatus contentChild = getErrorContentInfo(e);
-			assertThat(contentChild.getMessage(), containsString("<mar??tplace>"));
+			assertThat(contentChild.getMessage(), anyOf( //
+					containsString("<ma??etplace>"), // Windows
+					containsString("<mar??tplace>"))); // Linux
 		}
 	}
 

--- a/org.eclipse.epp.mpc.tests/src/org/eclipse/epp/mpc/tests/ui/wizard/AbstractMarketplaceWizardBotTest.java
+++ b/org.eclipse.epp.mpc.tests/src/org/eclipse/epp/mpc/tests/ui/wizard/AbstractMarketplaceWizardBotTest.java
@@ -108,19 +108,20 @@ public abstract class AbstractMarketplaceWizardBotTest {
 
 	protected static final INode[] TEST_NODES = new INode[] { //
 			testNode("206", "https://marketplace.eclipse.org/content/mylyn", "Mylyn"), //
-			testNode("311881", "https://marketplace.eclipse.org/content/eclipse-4-tools-css-spy",
-					"Eclipse 4 Tools: CSS Spy"), //
-			testNode("311774", "https://marketplace.eclipse.org/content/eclipse-4-tools-lightweight-css-editor",
-					"Eclipse 4 Tools: Lightweight CSS Editor"), //
-			testNode("311838", "https://marketplace.eclipse.org/content/eclipse-4-tools-application-model-editor", ""), //
+			testNode("2963400", "https://marketplace.eclipse.org/content/eclipse-web-developer-tools",
+					"Eclipse Web Developer Tools"), //
+			testNode("2953952", "https://marketplace.eclipse.org/content/eclipse-xml-editors-and-tools",
+					"Eclipse XML Editors and Tools"), //
+			testNode("507775", "https://marketplace.eclipse.org/content/dbeaver", "DBeaver"), //
 			testNode("2780381", "https://marketplace.eclipse.org/content/trace-compass", "Trace Compass"), //
 			testNode("2410217", "https://marketplace.eclipse.org/content/memory-analyzer-0", "Memory Analyzer"), //
 			testNode("1336", "https://marketplace.eclipse.org/content/egit-git-team-provider",
 					"EGit - Git Team Provider"), //
 			testNode("2706327", "https://marketplace.eclipse.org/content/eclipse-docker-tooling",
 					"Eclipse Docker Tooling"), //
-			testNode("2706342", "https://marketplace.eclipse.org/content/eclipse-vagrant-tooling",
-					"Eclipse Vagrant Tooling"), //
+			testNode("2963451",
+					"https://marketplace.eclipse.org/content/eclipse-enterprise-java-and-web-developer-tools",
+					"Eclipse Enterprise Java and Web Developer Tools"), //
 			testNode("2579663", "https://marketplace.eclipse.org/content/egerrit", "EGerrit") //
 	};
 

--- a/org.eclipse.epp.mpc.tests/src/org/eclipse/epp/mpc/tests/ui/wizard/MarketplaceWizardTest.java
+++ b/org.eclipse.epp.mpc.tests/src/org/eclipse/epp/mpc/tests/ui/wizard/MarketplaceWizardTest.java
@@ -48,7 +48,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-
 @Category({ RemoteTests.class, UITests.class })
 public class MarketplaceWizardTest extends AbstractMarketplaceWizardBotTest {
 
@@ -211,10 +210,9 @@ public class MarketplaceWizardTest extends AbstractMarketplaceWizardBotTest {
 	public void testFavorite() {
 		SWTBotButton favorite = bot.buttonWithId(AbstractMarketplaceDiscoveryItem.WIDGET_ID_KEY, DiscoveryItem.WIDGET_ID_RATING);
 		favorite.click();
-		SWTBotShell login = bot.shell("Authorizing with Marketplace User Storage");
-		login.bot().button("Cancel").click();
-		//TODO test something useful - we'd need a proper login on the server to do this...
-		//better to get started with some server mocking in the ui tests...
+		// NOTE: Favorite Button is not clickable since fd8acc192aa1689c27ec984db6eff362994b1925 https://github.com/eclipse-mpc/epp.mpc/issues/17
+		// SWTBotShell login = bot.shell("Authorizing with Marketplace User Storage");
+		// login.bot().button("Cancel").click();
 	}
 
 	@Test

--- a/org.eclipse.epp.mpc.tests/src/org/eclipse/epp/mpc/tests/util/TransportFactoryTest.java
+++ b/org.eclipse.epp.mpc.tests/src/org/eclipse/epp/mpc/tests/util/TransportFactoryTest.java
@@ -61,6 +61,7 @@ import org.eclipse.epp.internal.mpc.core.transport.httpclient.HttpClientService;
 import org.eclipse.epp.internal.mpc.core.transport.httpclient.HttpClientTransport;
 import org.eclipse.epp.internal.mpc.core.transport.httpclient.HttpClientTransportFactory;
 import org.eclipse.epp.internal.mpc.core.transport.httpclient.SynchronizedCredentialsProvider;
+import org.eclipse.epp.internal.mpc.core.transport.httpclient.SystemCredentialsProvider;
 import org.eclipse.epp.internal.mpc.core.util.FallbackTransportFactory;
 import org.eclipse.epp.internal.mpc.core.util.ServiceUtil;
 import org.eclipse.epp.internal.mpc.core.util.TransportFactory;
@@ -366,8 +367,7 @@ public class TransportFactoryTest {
 
 		assertNotNull(credentialsProvider);
 		List<CredentialsProvider> nestedProviders = listCredentialsProviders(credentialsProvider);
-		assertThat(nestedProviders, hasItem(LambdaMatchers.map(x -> x.getClass().getName()).matches(
-				"org.apache.http.impl.auth.win.WindowsCredentialsProvider")));
+		assertThat(nestedProviders, hasItem(instanceOf(SystemCredentialsProvider.class)));
 	}
 
 	private static AbortRequestCustomizer interceptRequest(HttpClientCustomizer... customizers) throws Exception {


### PR DESCRIPTION
It is currently not possible to successfully run the test suite on any OS because of multiple issues in the test setup.

This PR fixes addresses these issues and also restores the broken GitHub actions workflow. The workflow file has been updated to a similar configuration how we use it in the LSP4E and TM4E project. It configures matrix jobs and runs tests on all major OS against the oldest supported, current and staging Eclipse releases.