### PR TITLE
Compile against latest released Eclipse platform

### DIFF
--- a/org.eclipse.epp.mpc-target/staging.target
+++ b/org.eclipse.epp.mpc-target/staging.target
@@ -5,8 +5,7 @@
 <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.equinox.p2.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds"/>
-<!-- <repository location="https://download.eclipse.org/eclipse/updates/4.30"/> -->
+<repository location="https://download.eclipse.org/eclipse/updates/4.39"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
@@ -16,7 +15,6 @@
 <unit id="org.junit" version="0.0.0"/>
 <unit id="org.mockito.mockito-core" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
-<!-- repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2023-12"/ -->
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>


### PR DESCRIPTION
To allow tests to actually run when Marketplace is not yet aware of new platform version.