### PR TITLE
Handle response codes >= 300

### DIFF
--- a/org.eclipse.epp.mpc.core/src/org/eclipse/epp/internal/mpc/core/transport/httpclient/HttpClientTransport.java
+++ b/org.eclipse.epp.mpc.core/src/org/eclipse/epp/internal/mpc/core/transport/httpclient/HttpClientTransport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2018 The Eclipse Foundation and others.
+ * Copyright (c) 2010, 2026 The Eclipse Foundation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -125,6 +125,7 @@ public class HttpClientTransport implements ITransport {
 			@Override
 			protected InputStream handleResponse(ClassicHttpResponse response)
 					throws ClientProtocolException, IOException {
+				handleResponseStatus(response.getCode(), response.getReasonPhrase());
 				HttpEntity entity = response.getEntity();
 				byte[] contentBytes = EntityUtils.toByteArray(entity);
 				return new ByteArrayInputStream(contentBytes);


### PR DESCRIPTION
In these cases there is no HttpEntity thus a NPE in TransportFactoryTest.testHttpClientTransportErrorHandling