### PR TITLE
Ensure source compatibility with Eclipse 4.41

### DIFF
--- a/org.eclipse.epp.mpc.ui.css/META-INF/MANIFEST.MF
+++ b/org.eclipse.epp.mpc.ui.css/META-INF/MANIFEST.MF
@@ -15,5 +15,4 @@ Require-Bundle: org.eclipse.e4.ui.services;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.14.0,4.0.0)"
 Export-Package: org.eclipse.epp.internal.mpc.ui.css;x-friends:=org.eclipse.epp.mpc.ui
 Bundle-ActivationPolicy: lazy
-Import-Package: org.w3c.css.sac;version="[1.3.0,2.0.0)"
 Automatic-Module-Name: org.eclipse.epp.mpc.ui.css

--- a/org.eclipse.epp.mpc.ui.css/src/org/eclipse/epp/internal/mpc/ui/css/GradientCanvasPropertyHandler.java
+++ b/org.eclipse.epp.mpc.ui.css/src/org/eclipse/epp/internal/mpc/ui/css/GradientCanvasPropertyHandler.java
@@ -45,7 +45,7 @@ public class GradientCanvasPropertyHandler  extends AbstractCSSPropertySWTHandle
 					canvas.setBackgroundGradient(null, null, false);
 					return;
 				}
-				List<CSSPrimitiveValue> values = grad.getValues();
+				List<? extends CSSPrimitiveValue> values = grad.getValues();
 				List<Color> colors = new ArrayList<>(values.size());
 				for (CSSPrimitiveValue cssValue : values) {
 					if (cssValue != null) {

--- a/org.eclipse.epp.mpc.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.epp.mpc.ui/META-INF/MANIFEST.MF
@@ -36,6 +36,5 @@ Export-Package: org.eclipse.epp.internal.mpc.ui;x-internal:=true,
  org.eclipse.epp.mpc.ui
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/services/*.xml
-Import-Package: org.osgi.service.component;version="[1.5.1,2.0.0)",
- org.w3c.css.sac;version="[1.3.0,2.0.0)"
+Import-Package: org.osgi.service.component;version="[1.5.1,2.0.0)"
 Automatic-Module-Name: org.eclipse.epp.mpc.ui

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
       <java-bree>JavaSE-${java-version}</java-bree>
       <java-jdk>SYSTEM</java-jdk>
 
-      <tycho-version>5.0.2</tycho-version>
+      <tycho-version>5.0.3</tycho-version>
 
       <qualifier-format>'v'yyyyMMdd-HHmm</qualifier-format>
 


### PR DESCRIPTION
- Use Tycho 5.0.3.
- Remove package imports of org.w3c.css.sac.

https://github.com/eclipse-mpc/epp.mpc/issues/66